### PR TITLE
Fix: Failing leave workspace tests 

### DIFF
--- a/e2e/tests/settings/leave-company.spec.ts
+++ b/e2e/tests/settings/leave-company.spec.ts
@@ -61,7 +61,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/equity/dividends");
+    await expect(page).toHaveURL("/invoices");
 
     const investor = await db.query.companyInvestors.findFirst({
       where: and(eq(companyInvestors.companyId, company.id), eq(companyInvestors.userId, user.id)),
@@ -86,7 +86,7 @@ test.describe("Leave company", () => {
     await expect(page.getByText("Leave this workspace?")).toBeVisible();
     await page.getByRole("button", { name: "Leave" }).click();
 
-    await expect(page).toHaveURL("/documents");
+    await expect(page).toHaveURL("/invoices");
 
     const lawyer = await db.query.companyLawyers.findFirst({
       where: and(eq(companyLawyers.companyId, company.id), eq(companyLawyers.userId, user.id)),


### PR DESCRIPTION
Testing

- Updated expected URL after leaving workspace from '/equity/dividends' and '/documents' to '/invoices'.

